### PR TITLE
feat: Add 'Quiénes Somos' page

### DIFF
--- a/pages/quienes-somos.html
+++ b/pages/quienes-somos.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quiénes Somos | Cartagena Entertainment Rent and Pleasure</title>
+    <meta name="description" content="Conoce nuestra historia, misión, visión y valores. Somos expertos en crear experiencias de lujo inolvidables en el Caribe.">
+
+    <!-- Google Fonts: Poppins y Montserrat -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+
+    <!-- Font Awesome para iconos -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+    <!-- Hoja de Estilos Principal -->
+    <link rel="stylesheet" href="../styles/main.css">
+</head>
+<body>
+    <main>
+        <!-- ======== SECCIÓN 1: HERO DE PRESENTACIÓN ======== -->
+        <section class="hero hero-about">
+            <div class="hero-content">
+                <h1>Más que un alquiler, una experiencia inolvidable.</h1>
+                <p>En Cartagena Entertainment Rent and Pleasure, transformamos el lujo en un estilo de vida que abarca aventura, confort y placer en su máxima expresión.</p>
+            </div>
+        </section>
+
+        <!-- ======== SECCIÓN 2: NUESTRA ESENCIA ======== -->
+        <section class="section container">
+            <div class="about-essence-content">
+                <div class="about-text">
+                    <h2>Expertos en Momentos Únicos</h2>
+                    <p>Nuestra oferta está diseñada para quienes buscan exclusividad y emoción: desde yates, veleros y catamaranes para explorar el Caribe, hasta powercats y botes deportivos para los amantes de la velocidad.</p>
+                    <p>Complementamos nuestras aventuras marítimas con mansiones de lujo, automóviles de alta gama y expediciones de pesca deportiva, asegurando distinción y confort en cada detalle.</p>
+                </div>
+                <div class="about-image">
+                    <img src="../assets/images/about-us-team.jpg" alt="Equipo de Cartagena Entertainment">
+                </div>
+            </div>
+        </section>
+
+        <!-- ======== SECCIÓN 3: MISIÓN Y VISIÓN ======== -->
+        <section class="section section-light">
+            <div class="container">
+                <h2>Nuestro Horizonte</h2>
+                <div class="mission-vision-grid">
+                    <div class="card mission-card">
+                        <i class="fas fa-anchor value-icon"></i>
+                        <h3>Nuestra Misión</h3>
+                        <p>Ofrecer experiencias de lujo y entretenimiento que superen todas las expectativas, respaldados por un firme compromiso con la calidad, la seguridad y la responsabilidad para garantizar momentos inolvidables.</p>
+                    </div>
+                    <div class="card vision-card">
+                        <i class="fas fa-rocket value-icon"></i>
+                        <h3>Nuestra Visión</h3>
+                        <p>Ser la empresa líder global en el mercado del lujo, reconocida por nuestra excelencia, exclusividad y la capacidad de posicionar a Cartagena como el destino preferido para quienes buscan aventura y placer.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- ======== SECCIÓN 4: NUESTRA INSPIRACIÓN ======== -->
+        <section class="section section-dark inspiration-content">
+            <div class="container">
+                <div class="inspiration-text">
+                    <h2>Inspirados en la Luna Verde</h2>
+                    <p>Nacimos del deseo de brindar experiencias memorables. Los colores de nuestro logo son un homenaje a las noches mágicas del 'Festival de la Luna Verde' de San Andrés, una celebración que resalta las tradiciones, la alegría y el entusiasmo de la cultura afrocaribeña.</p>
+                </div>
+                <div class="inspiration-image">
+                    <img src="../assets/images/green-moon.jpg" alt="Inspiración Luna Verde">
+                </div>
+            </div>
+        </section>
+
+        <!-- ======== SECCIÓN 5: NUESTROS VALORES ======== -->
+        <section class="section container">
+            <h2 class="section-title">Nuestros Pilares</h2>
+            <div class="values-grid">
+                <div class="value-card"><div class="value-content"><i class="fas fa-star value-icon"></i><span class="value-title">Excelencia</span></div><div class="value-description">Compromiso con la más alta calidad en cada detalle.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-shield-alt value-icon"></i><span class="value-title">Seguridad</span></div><div class="value-description">Garantizamos la tranquilidad y protección de nuestros clientes.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-leaf value-icon"></i><span class="value-title">Responsabilidad</span></div><div class="value-description">Cuidamos el medio ambiente y las comunidades locales.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-gem value-icon"></i><span class="value-title">Exclusividad</span></div><div class="value-description">Ofrecemos experiencias únicas y personalizadas.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-lightbulb value-icon"></i><span class="value-title">Innovación</span></div><div class="value-description">Buscamos constantemente nuevas formas de sorprender.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-sun value-icon"></i><span class="value-title">Cultura Caribeña</span></div><div class="value-description">Celebramos y compartimos la riqueza de nuestra cultura.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-user-check value-icon"></i><span class="value-title">Atención Personalizada</span></div><div class="value-description">Cada cliente es único y nos adaptamos a sus necesidades.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-balance-scale value-icon"></i><span class="value-title">Integridad</span></div><div class="value-description">Actuamos con honestidad y transparencia en todo momento.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-users value-icon"></i><span class="value-title">Trabajo en Equipo</span></div><div class="value-description">Colaboramos para lograr resultados extraordinarios.</div></div>
+                <div class="value-card"><div class="value-content"><i class="fas fa-smile-beam value-icon"></i><span class="value-title">Alegría y Entusiasmo</span></div><div class="value-description">Contagiamos nuestra pasión por lo que hacemos.</div></div>
+            </div>
+        </section>
+
+        <!-- ======== SECCIÓN 6: LLAMADO A LA ACCIÓN (CTA) ======== -->
+        <section class="cta-section">
+            <div class="container">
+                <h2>¿Listo para vivir tu propia historia?</h2>
+                <a href="mailto:info@aventuracaribe.com" class="btn btn-primary">Explora Nuestras Experiencias</a>
+            </div>
+        </section>
+
+    </main>
+    <script src="../scripts/loadComponents-pages.js"></script>
+    <script src="../scripts/main.js" defer></script>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -504,6 +504,138 @@ body {
 }
 
 /* =================================
+   PÁGINA QUIÉNES SOMOS
+   ================================= */
+.hero-about {
+    background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)), url('../assets/images/hero-yacht-sunset.jpg') no-repeat center center/cover;
+}
+
+.about-essence-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
+    align-items: center;
+}
+
+.about-essence-content .about-image img {
+    width: 100%;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+.mission-vision-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 40px;
+    margin-top: 30px;
+}
+
+.mission-card, .vision-card {
+    background-color: var(--color-background);
+    padding: 35px;
+    border-radius: var(--border-radius);
+    text-align: center;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+}
+
+.mission-card h3, .vision-card h3 {
+    font-family: var(--font-secondary);
+    margin-bottom: 15px;
+    color: var(--color-dark);
+}
+
+.inspiration-content .container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 50px;
+    align-items: center;
+}
+
+.inspiration-image img {
+    width: 100%;
+    border-radius: var(--border-radius);
+    object-fit: cover;
+}
+
+.values-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 25px;
+    margin-top: 40px;
+}
+
+.value-card {
+    background: var(--color-white);
+    border: 1px solid #e0e0e0;
+    border-radius: var(--border-radius);
+    padding: 20px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.value-card:hover {
+    transform: translateY(-5px);
+    box-shadow: var(--box-shadow);
+}
+
+.value-content {
+    transition: opacity 0.4s ease;
+}
+
+.value-card:hover .value-content {
+    opacity: 0;
+}
+
+.value-icon {
+    font-size: 2.5rem;
+    color: var(--color-primary);
+    margin-bottom: 15px;
+}
+
+.value-title {
+    font-weight: 600;
+    display: block;
+}
+
+.value-description {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--color-primary);
+    color: var(--color-white);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 15px;
+    font-size: 0.9rem;
+    opacity: 0;
+    transform: translateY(100%);
+    transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.value-card:hover .value-description {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.cta-section {
+    padding: 60px 0;
+    text-align: center;
+    background-color: var(--color-light);
+}
+
+.cta-section h2 {
+    font-family: var(--font-secondary);
+    font-size: 2.2rem;
+    margin-bottom: 30px;
+}
+
+
+/* =================================
    DISEÑO RESPONSIVE
    ================================= */
 @media (max-width: 768px) {
@@ -520,11 +652,22 @@ body {
         font-size: 2.5rem;
     }
 
-    .about-us-content {
+    .about-us-content,
+    .about-essence-content,
+    .inspiration-content .container {
         flex-direction: column;
+        grid-template-columns: 1fr;
     }
 
     .contact-content {
         flex-direction: column;
+    }
+
+    .values-grid {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    }
+
+    .cta-section h2 {
+        font-size: 1.8rem;
     }
 }


### PR DESCRIPTION
This commit introduces the new 'Quiénes Somos' (About Us) page to the website.

The page is located at `pages/quienes-somos.html` and includes the following sections as requested:
- Hero section with a welcoming message.
- "Nuestra Esencia" section detailing the company's focus.
- "Misión y Visión" section.
- "Nuestra Inspiración" section explaining the brand's origin.
- "Nuestros Valores" section with an interactive grid.
- A final Call to Action (CTA) section.

New styles have been added to `styles/main.css` to support this page, ensuring a responsive design that aligns with the existing visual identity. The changes also include responsive styles for mobile devices.